### PR TITLE
Fix typos

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -80,7 +80,7 @@ charToRaw(s2)
 
 Some Unicode glyphs, e.g. typical emojis, are *wide*. They are supposed to take up two characters in a monospace font. The set of wide glyphs (just like the set of glyphs in general) has been changing in different Unicode versions.
 
-Up to version 4.0.3 R followed Unicode 8 (released in 2015) in terms of character width, so `nchar(..., type = "width")` miscalculated the width of many Asian characters .
+Up to version 4.0.3 R followed Unicode 8 (released in 2015) in terms of character width, so `nchar(..., type = "width")` miscalculated the width of many Asian characters.
 
 R 4.0.4 follows Unicode 12.1.
 
@@ -166,7 +166,7 @@ R uses the native encoding extensively. Some examples:
 -   Output connections assume that the output is in this encoding.
 -   Input connection convert the input into this encoding.
 -   `enc2native()` encodes its input into this encoding.
--   Printing to the screen (via `cat()`, `print()`, `writeLines()`, etc. re-encodes strings into this encoding.
+-   Printing to the screen (via `cat()`, `print()`, `writeLines()`, etc.) re-encodes strings into this encoding.
 
 It is surprisingly tricky to query the current native encoding, especially on older R versions. Here are a number of things to try:
 
@@ -230,7 +230,7 @@ It is surprisingly tricky to query the current native encoding, especially on ol
     [1] "A\n3\n262148\n197888\n5\nUTF-8\n254\n"
     ```
 
-    Line number 6 in the output is the name of the encoding. On R 4.0.x you can also save and RDS file and then use the `infoRDS()` function on it to see the current native encoding.
+    Line number 6 (i.e. after the fifth `\n`) in the output is the name of the encoding. On R 4.0.x you can also save an RDS file and then use the `infoRDS()` function on it to see the current native encoding.
 
 5.  Otherwise can call `Sys.getlocale()` and parsing its output will probably give you an encoding name that works in `iconv()`:
 
@@ -296,7 +296,7 @@ read_utf8 <- function (path) {
 Explanation and notes:
 
 -   `path` must be a file name, or an un-opened connection, or a connection that was opened in the native encoding (i.e. with `encoding = "native.enc"`). Otherwise `read_utf8()` might (silently) return lines in the wrong encoding.
--   If `readLines()` gets a file name, then it opens a connection to it in `UTF-8` , so the file is not re-encoded and it also marks the result as `UTF-8`.
+-   If `readLines()` gets a file name, then it opens a connection to it in `UTF-8`, so the file is not re-encoded and it also marks the result as `UTF-8`.
 -   For extra safety, you can add a check that `path` is a file name.
 -   As far as I can tell, there is no R API to query the encoding of a connection.
 
@@ -372,7 +372,7 @@ No, in general they are not, but the situation is quite good. If you save an RDS
 
 -   all text is either UTF-8 and latin1 encoded, and they are also marked as such, or
 -   both computers (or settings) have the same native encoding,
--   the RDS file has version 3, and the the loading platform can represent all characters in the RDS file. This usually holds if the loading platform is UTF-8.
+-   the RDS file has version 3, and the loading platform can represent all characters in the RDS file. This usually holds if the loading platform is UTF-8.
 
 Note that from RDS version 3 the strings in the native encoding are re-encoded to the current native encoding when the RDS file is loaded.
 
@@ -482,7 +482,7 @@ TODO
 
 -   `charToRaw()` is your best friend.
 
--   Don't forget, if they print the same, if they are `identical()` , they can still be in a different encoding. `charToRaw()` is your best friend.
+-   Don't forget, if they print the same, if they are `identical()`, they can still be in a different encoding. `charToRaw()` is your best friend.
 
 -   `testthat::CheckReporter` saves a `testthat-problems.rds` file, if there were any test failures. You can get this file from win-builder, R-hub, etc. The file is a version 2 RDS file, so no encoding conversion will be done by `readRDS()`.
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Unicode versions.
 
 Up to version 4.0.3 R followed Unicode 8 (released in 2015) in terms of
 character width, so `nchar(..., type = "width")` miscalculated the width
-of many Asian characters .
+of many Asian characters.
 
 R 4.0.4 follows Unicode 12.1.
 
@@ -283,8 +283,8 @@ R uses the native encoding extensively. Some examples:
 -   Output connections assume that the output is in this encoding.
 -   Input connection convert the input into this encoding.
 -   `enc2native()` encodes its input into this encoding.
--   Printing to the screen (via `cat()`, `print()`, `writeLines()`, etc.
-    re-encodes strings into this encoding.
+-   Printing to the screen (via `cat()`, `print()`, `writeLines()`,
+    etc.) re-encodes strings into this encoding.
 
 It is surprisingly tricky to query the current native encoding,
 especially on older R versions. Here are a number of things to try:
@@ -353,9 +353,10 @@ especially on older R versions. Here are a number of things to try:
     [1] "A\n3\n262148\n197888\n5\nUTF-8\n254\n"
     ```
 
-    Line number 6 in the output is the name of the encoding. On R 4.0.x
-    you can also save and RDS file and then use the `infoRDS()` function
-    on it to see the current native encoding.
+    Line number 6 (i.e. after the fifth `\n`) in the output is the name
+    of the encoding. On R 4.0.x you can also save an RDS file and then
+    use the `infoRDS()` function on it to see the current native
+    encoding.
 
 5.  Otherwise can call `Sys.getlocale()` and parsing its output will
     probably give you an encoding name that works in `iconv()`:
@@ -434,7 +435,7 @@ Explanation and notes:
     `encoding = "native.enc"`). Otherwise `read_utf8()` might (silently)
     return lines in the wrong encoding.
 -   If `readLines()` gets a file name, then it opens a connection to it
-    in `UTF-8` , so the file is not re-encoded and it also marks the
+    in `UTF-8`, so the file is not re-encoded and it also marks the
     result as `UTF-8`.
 -   For extra safety, you can add a check that `path` is a file name.
 -   As far as I can tell, there is no R API to query the encoding of a
@@ -530,9 +531,9 @@ settings), if at least one these conditions hold:
 -   all text is either UTF-8 and latin1 encoded, and they are also
     marked as such, or
 -   both computers (or settings) have the same native encoding,
--   the RDS file has version 3, and the the loading platform can
-    represent all characters in the RDS file. This usually holds if the
-    loading platform is UTF-8.
+-   the RDS file has version 3, and the loading platform can represent
+    all characters in the RDS file. This usually holds if the loading
+    platform is UTF-8.
 
 Note that from RDS version 3 the strings in the native encoding are
 re-encoded to the current native encoding when the RDS file is loaded.
@@ -670,7 +671,7 @@ TODO
 
 -   `charToRaw()` is your best friend.
 
--   Don’t forget, if they print the same, if they are `identical()` ,
+-   Don’t forget, if they print the same, if they are `identical()`,
     they can still be in a different encoding. `charToRaw()` is your
     best friend.
 

--- a/what-every.Rmd
+++ b/what-every.Rmd
@@ -139,7 +139,7 @@ Unicode is an information technology standard for the consistent encoding, repre
 
     -   `unknown`
 
--   If the native encoding is not UTF-8 or latin1, native strings are marked as `unknown`. But `unkown` means different things on different platforms.
+-   If the native encoding is not UTF-8 or latin1, native strings are marked as `unknown`. But `unknown` means different things on different platforms.
 
 ## What encoding should I use?
 
@@ -238,7 +238,7 @@ Aligning text with *wide* Unicode characters is hard.
 
 -   `charToRaw()` is your best friend.
 
--   Don't forget, if they print the same, if they are `identical()` , they can still be in a different encoding. `charToRaw()` is your best friend.
+-   Don't forget, if they print the same, if they are `identical()`, they can still be in a different encoding. `charToRaw()` is your best friend.
 
 -   `testthat::CheckReporter` saves a `testthat-problems.rds` file, if there were any test failures. You can get this file from win-builder, R-hub, etc. The file is a version 2 RDS file, so no encoding conversion will be done by `readRDS()`.
 

--- a/what-every.md
+++ b/what-every.md
@@ -151,6 +151,9 @@ world’s writing systems.
         ## 
         ## $`Latin-1`
         ## [1] FALSE
+        ## 
+        ## $codeset
+        ## [1] "UTF-8"
 
 -   It is possible to *declare* the encoding of a string (not character
     vector). (!)
@@ -203,7 +206,7 @@ world’s writing systems.
     -   `unknown`
 
 -   If the native encoding is not UTF-8 or latin1, native strings are
-    marked as `unknown`. But `unkown` means different things on
+    marked as `unknown`. But `unknown` means different things on
     different platforms.
 
 ## What encoding should I use?
@@ -339,7 +342,7 @@ Aligning text with *wide* Unicode characters is hard.
 
 -   `charToRaw()` is your best friend.
 
--   Don’t forget, if they print the same, if they are `identical()` ,
+-   Don’t forget, if they print the same, if they are `identical()`,
     they can still be in a different encoding. `charToRaw()` is your
     best friend.
 


### PR DESCRIPTION
This PR mainly fix typos. I also added one minor clarification. 

1 quick comment, in the README you wrote

>  This will be hopefully fixed in the next version of brio, with <https://github.com/r-lib/brio/pull/15>

The PR has been merged, so may be worth removing this.

Thank you for this, a very useful read. 